### PR TITLE
Add Remote Job Assistant to job listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ _Please check the [contribution guidelines](contributing.md) for info on formatt
 - [Freelancer](http://freelancer.com) - The world's largest freelancing and crowdsourcing marketplace by number of users and projects, connecting over 22 million employers and freelancers.
 - [Toptal](https://toptal.com) - Join an exclusive network of the top freelance software developers, designers, and finance experts in the world. Top companies rely on Toptal freelancers for their most important projects.
 - [DailyRemote](https://dailyremote.com) - Filter and find remote jobs for every role.
+- [Remote Job Assistant](https://remotejobassistant.com) - Remote jobs for non-technical workers.
 
 ## Workspaces
 - [Workfrom](http://workfrom.co) - The most comprehensive directory of public and private workspaces across the globe.


### PR DESCRIPTION
Adding Remote Job Assistant - a job board specifically focused on remote positions for non-technical workers.

Unlike most remote job boards that cater primarily to developers and tech roles, Remote Job Assistant focuses on customer service, administrative, marketing, and other non-technical remote positions. This makes it a good resource for digital nomads who aren't in tech but still want location-independent work.

Website: https://remotejobassistant.com/